### PR TITLE
feat: enable AdGuard DNS ad-blocking on exit server

### DIFF
--- a/scripts/lib/xray.sh
+++ b/scripts/lib/xray.sh
@@ -36,6 +36,13 @@ configure_xray_exit() {
         "access": "/var/log/xray/access.log",
         "error": "/var/log/xray/error.log"
     },
+    "dns": {
+        "servers": [
+            "94.140.14.14",
+            "94.140.15.15",
+            "1.1.1.1"
+        ]
+    },
     "inbounds": [
         {
             "tag": "vless-reality-in",


### PR DESCRIPTION
## Summary

- Add `dns` section to XRAY exit server config with AdGuard DNS servers (94.140.14.14, 94.140.15.15) for ad/tracker filtering
- Cloudflare 1.1.1.1 as fallback if AdGuard is unreachable
- XRAY resolves DNS in declared order — AdGuard filters ads, trackers and telemetry (e.g. Meta netseer, fbcdn tracking)

## Details

Zero performance impact — blocked domains save bandwidth and load time. No changes to routing, inbounds, or outbounds.

Affects only new deployments (existing servers need re-run of `setup.sh exit` or manual config edit).

## Test plan

- [x] Deploy exit server with `setup.sh exit` and verify `/usr/local/etc/xray/config.json` contains `dns` section
- [x] Verify XRAY starts without errors: `systemctl status xray`
- [x] Test ad-blocking: connect via VPN and check that known ad domains (e.g. `ads.google.com`) are blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)