### PR TITLE
feat: force DNS re-resolution for ad filtering

### DIFF
--- a/scripts/lib/xray.sh
+++ b/scripts/lib/xray.sh
@@ -82,7 +82,10 @@ configure_xray_exit() {
     "outbounds": [
         {
             "tag": "direct",
-            "protocol": "freedom"
+            "protocol": "freedom",
+            "settings": {
+                "domainStrategy": "UseIP"
+            }
         },
         {
             "tag": "block",


### PR DESCRIPTION
## Summary

- Add `domainStrategy: UseIP` to freedom outbound on exit server
- Forces XRAY to resolve domains through its own DNS (AdGuard) instead of trusting client-provided IPs

## Problem

Clients resolve DNS locally before sending traffic through VPN. XRAY receives pre-resolved IPs and forwards them directly, bypassing AdGuard DNS filtering. Ad domains like `adtng.com` and `trafficjunky.com` pass through even though AdGuard returns 0.0.0.0 for them.

## Fix

With `domainStrategy: UseIP`, XRAY re-resolves domains via its configured DNS servers (AdGuard) before connecting. Blocked domains get 0.0.0.0 and the connection fails — ads don't load.

## Test plan

- [ ] Run `setup.sh update-exit` on exit server
- [ ] Connect to VPN, visit ad-heavy site
- [ ] Check logs — ad domains should no longer appear or should fail to connect