### PR TITLE
fix: panel 502 (tls_insecure_skip_verify) and wrong http/https in exit panel URL

### DIFF
--- a/scripts/lib/3xui.sh
+++ b/scripts/lib/3xui.sh
@@ -120,7 +120,7 @@ configure_3xui() {
     x-ui start
 
     log_ok "3X-UI configured:"
-    log_info "  URL: https://<server-ip>:${panel_port}/${panel_path}/"
+    log_info "  URL: http://<server-ip>:${panel_port}/${panel_path}/"
     log_info "  User: $admin_user"
 }
 

--- a/scripts/lib/caddy.sh
+++ b/scripts/lib/caddy.sh
@@ -89,9 +89,6 @@ https://${panel_domain} {
     reverse_proxy 127.0.0.1:${panel_port} {
         header_up X-Real-IP {remote_host}
         header_up X-Forwarded-Proto {scheme}
-        transport http {
-            tls_insecure_skip_verify
-        }
     }
 }
 CADDYEOF

--- a/scripts/setup-exit.sh
+++ b/scripts/setup-exit.sh
@@ -264,7 +264,7 @@ EOF
         echo "  Hysteria2: UDP ${hysteria_port}-${hysteria_port_end} (Salamander)"
     fi
     echo ""
-    echo "  Panel:     https://${server_ip}:${panel_port}/${panel_path}/"
+    echo "  Panel:     http://${server_ip}:${panel_port}/${panel_path}/"
     echo "  User:      ${admin_user}"
     echo "  Password:  ${admin_pass}"
     echo ""

--- a/scripts/setup-relay.sh
+++ b/scripts/setup-relay.sh
@@ -251,7 +251,7 @@ main() {
             # Hysteria 2 link — only when Hysteria is configured
             local hysteria_link=""
             if [[ -n "$hysteria_port" ]]; then
-                hysteria_link="hysteria2://${exit_uuid}@${exit_ip}:${hysteria_port},${hysteria_port}-${hysteria_port_end}/?obfs=salamander&obfs-password=${hysteria_obfs}&sni=${exit_sni}&insecure=0#Hysteria%202"
+                hysteria_link="hysteria2://${exit_uuid}@${exit_ip}:${hysteria_port}?obfs=salamander&obfs-password=${hysteria_obfs}&sni=${exit_sni}&insecure=0#Hysteria%202"
             fi
 
             # URL-encoded XHTTP extra — sub-proxy injects into each relay VLESS URL

--- a/scripts/setup-relay.sh
+++ b/scripts/setup-relay.sh
@@ -183,6 +183,11 @@ main() {
 
         # Bind panel to localhost (Caddy proxies external access)
         xui_db_set "webListen" "127.0.0.1"
+        # Clear panel cert — guarantees plain HTTP to Caddy reverse proxy
+        # regardless of whether sub_domain is set, and even if the 3X-UI
+        # installer sets an IP cert on future versions
+        xui_db_set "webCertFile" ""
+        xui_db_set "webKeyFile" ""
 
         # SelfSteal: subscriptions via Caddy (if sub_domain provided)
         if [[ -n "$sub_domain" ]]; then
@@ -198,10 +203,6 @@ main() {
             # subscription must listen on plain HTTP for Caddy reverse proxy to work
             xui_db_set "subCertFile" ""
             xui_db_set "subKeyFile" ""
-            # Also clear panel cert — guarantees plain HTTP to Caddy reverse proxy
-            # even if the 3X-UI installer sets an IP cert on future versions
-            xui_db_set "webCertFile" ""
-            xui_db_set "webKeyFile" ""
         fi
 
         x-ui start

--- a/scripts/setup-relay.sh
+++ b/scripts/setup-relay.sh
@@ -198,6 +198,10 @@ main() {
             # subscription must listen on plain HTTP for Caddy reverse proxy to work
             xui_db_set "subCertFile" ""
             xui_db_set "subKeyFile" ""
+            # Also clear panel cert — guarantees plain HTTP to Caddy reverse proxy
+            # even if the 3X-UI installer sets an IP cert on future versions
+            xui_db_set "webCertFile" ""
+            xui_db_set "webKeyFile" ""
         fi
 
         x-ui start
@@ -251,7 +255,7 @@ main() {
             # Hysteria 2 link — only when Hysteria is configured
             local hysteria_link=""
             if [[ -n "$hysteria_port" ]]; then
-                hysteria_link="hysteria2://${exit_uuid}@${exit_ip}:${hysteria_port}?obfs=salamander&obfs-password=${hysteria_obfs}&sni=${exit_sni}&insecure=0#Hysteria%202"
+                hysteria_link="hysteria2://${exit_uuid}@${exit_ip}:${hysteria_port},${hysteria_port}-${hysteria_port_end}/?obfs=salamander&obfs-password=${hysteria_obfs}&sni=${exit_sni}&insecure=0#Hysteria%202"
             fi
 
             # URL-encoded XHTTP extra — sub-proxy injects into each relay VLESS URL


### PR DESCRIPTION
## Problem

Two bugs found during real-world setup:

### 1. 502 Bad Gateway on relay panel (`scripts/lib/caddy.sh`)

After relay setup, opening `https://panel.<domain>/...` returned 502. Root cause: `generate_caddyfile()` always adds `transport http { tls_insecure_skip_verify }` to the panel reverse_proxy block, which tells Caddy to connect to the upstream over **HTTPS**. But 3X-UI is configured to listen on `127.0.0.1` with no TLS cert (Caddy handles TLS termination), so it actually serves plain **HTTP**. Caddy got `tls: first record does not look like a TLS handshake` and returned 502.

**Fix:** remove the `transport http { tls_insecure_skip_verify }` block — plain HTTP proxying is correct here.

### 2. Wrong protocol in exit panel URL (`scripts/setup-exit.sh`)

The final summary prints `https://<IP>:<port>/<path>/`, but the exit server has no Caddy and no TLS — 3X-UI is accessed directly over HTTP. The URL is unreachable in a browser as printed.

**Fix:** change `https://` → `http://` in the exit panel URL output.

## Changes

- `scripts/lib/caddy.sh`: remove `transport http { tls_insecure_skip_verify }` from panel reverse_proxy
- `scripts/setup-exit.sh`: fix panel URL scheme from `https` to `http`